### PR TITLE
Fix dynamic assertion checking

### DIFF
--- a/src/Rbac.php
+++ b/src/Rbac.php
@@ -139,13 +139,15 @@ class Rbac extends AbstractIterator
      */
     public function isGranted($role, $permission, $assert = null)
     {
+        $result = $this->getRole($role)->hasPermission($permission);
+
         if ($assert) {
             if ($assert instanceof AssertionInterface) {
-                return (bool) $assert->assert($this);
+                return $result && $assert->assert($this);
             }
 
             if (is_callable($assert)) {
-                return (bool) $assert($this);
+                return $result && $assert($this);
             }
 
             throw new Exception\InvalidArgumentException(
@@ -153,6 +155,6 @@ class Rbac extends AbstractIterator
             );
         }
 
-        return $this->getRole($role)->hasPermission($permission);
+        return $result;
     }
 }

--- a/test/Assertion/CallbackAssertionTest.php
+++ b/test/Assertion/CallbackAssertionTest.php
@@ -48,6 +48,7 @@ class CallbackAssertionTest extends \PHPUnit_Framework_TestCase
         });
         $foo  = new Rbac\Role('foo');
         $foo->addPermission('can.foo');
+        $rbac->addRole($foo);
         $this->assertFalse($rbac->isGranted($foo, 'can.foo', $assert));
     }
 

--- a/test/RbacTest.php
+++ b/test/RbacTest.php
@@ -46,6 +46,9 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(true, $this->rbac->isGranted($foo, 'can.foo', $true));
         $this->assertEquals(false, $this->rbac->isGranted($bar, 'can.bar', $false));
 
+        $this->assertEquals(false, $this->rbac->isGranted($foo, 'cannot', $true));
+        $this->assertEquals(false, $this->rbac->isGranted($bar, 'cannot', $false));
+
         $this->assertEquals(false, $this->rbac->isGranted($bar, 'can.bar', $roleNoMatch));
         $this->assertEquals(false, $this->rbac->isGranted($bar, 'can.foo', $roleNoMatch));
 


### PR DESCRIPTION
See issue #20.

Note the line in `RbacTest`:

    $this->assertEquals(false, $this->rbac->isGranted($foo, 'cannot', $true));

This is a breaking change and should probably lead to a major version number increase.