### PR TITLE
Fix for multiple parents in Role

### DIFF
--- a/doc/book/methods.md
+++ b/doc/book/methods.md
@@ -27,7 +27,8 @@ Method signature                               | Description
 `getName() : string`                           | Retrieve the name assigned to this role.
 `hasPermission(string $name) : bool`           | Does the role have the given permission?
 `setParent(RoleInterface $parent) : void`      | Assign the provided role as the current role's parent.
-`getParent() null|RoleInterface`               | Retrieve the current role's parent, if one exists.
+`addParent(RoleInterface $parent) : Role`      | Add a parent role to the current instance.
+`getParent() null|RoleInterface|array`         | Retrieve the current role's parent, or array of parents if more that one exists.
 
 ## `Zend\Permissions\Rbac\AssertionInterface`
 

--- a/src/AbstractRole.php
+++ b/src/AbstractRole.php
@@ -114,7 +114,7 @@ abstract class AbstractRole extends AbstractIterator implements RoleInterface
     public function getParent()
     {
         if (null === $this->parents) {
-            return null;
+            return;
         }
         if (1 === count($this->parents)) {
             return $this->parents[0];

--- a/src/AbstractRole.php
+++ b/src/AbstractRole.php
@@ -90,26 +90,22 @@ abstract class AbstractRole extends AbstractIterator implements RoleInterface
                 'Child must be a string or implement Zend\Permissions\Rbac\RoleInterface'
             );
         }
-
-        $child->setParent($this);
-        $this->children[] = $child;
-
+        if (! in_array($child, $this->children, true)) {
+            $this->children[] = $child;
+            $child->setParent($this);
+        }
         return $this;
     }
 
     /**
+     * @deprecated deprecated since version 2.6.0, use addParent() instead
+     *
      * @param  RoleInterface $parent
      * @return RoleInterface
      */
     public function setParent($parent)
     {
-        if (null === $this->parents) {
-            $this->parents = [];
-        }
-        if (!in_array($parent, $this->parents)) {
-            $this->parents[] = $parent;
-        }
-        return $this;
+        return $this->addParent($parent);
     }
 
     /**
@@ -117,6 +113,9 @@ abstract class AbstractRole extends AbstractIterator implements RoleInterface
      */
     public function getParent()
     {
+        if (null === $this->parents) {
+            return null;
+        }
         if (1 === count($this->parents)) {
             return $this->parents[0];
         }
@@ -129,7 +128,18 @@ abstract class AbstractRole extends AbstractIterator implements RoleInterface
      */
     public function addParent($parent)
     {
-        $parent->addChild($this);
-        return $this->setParent($parent);
+        if (! $parent instanceof RoleInterface) {
+            throw new Exception\InvalidArgumentException(
+                'Parent must implement Zend\Permissions\Rbac\RoleInterface'
+            );
+        }
+        if (null === $this->parents) {
+            $this->parents = [];
+        }
+        if (! in_array($parent, $this->parents, true)) {
+            $this->parents[] = $parent;
+            $parent->addChild($this);
+        }
+        return $this;
     }
 }

--- a/src/AbstractRole.php
+++ b/src/AbstractRole.php
@@ -14,9 +14,9 @@ use RecursiveIteratorIterator;
 abstract class AbstractRole extends AbstractIterator implements RoleInterface
 {
     /**
-     * @var null|RoleInterface
+     * @var null|array
      */
-    protected $parent;
+    protected $parents;
 
     /**
      * @var string
@@ -103,16 +103,23 @@ abstract class AbstractRole extends AbstractIterator implements RoleInterface
      */
     public function setParent($parent)
     {
-        $this->parent = $parent;
-
+        if (null === $this->parents) {
+            $this->parents = [];
+        }
+        if (!in_array($parent, $this->parents)) {
+            $this->parents[] = $parent;
+        }
         return $this;
     }
 
     /**
-     * @return null|RoleInterface
+     * @return null|RoleInterface|array
      */
     public function getParent()
     {
-        return $this->parent;
+        if (1 === count($this->parents)) {
+          return $this->parents[0];
+        }
+        return $this->parents;
     }
 }

--- a/src/AbstractRole.php
+++ b/src/AbstractRole.php
@@ -122,4 +122,14 @@ abstract class AbstractRole extends AbstractIterator implements RoleInterface
         }
         return $this->parents;
     }
+
+    /**
+     * @param  RoleInterface $parent
+     * @return RoleInterface
+     */
+    public function addParent($parent)
+    {
+        $parent->addChild($this);
+        return $this->setParent($parent);
+    }
 }

--- a/src/AbstractRole.php
+++ b/src/AbstractRole.php
@@ -118,7 +118,7 @@ abstract class AbstractRole extends AbstractIterator implements RoleInterface
     public function getParent()
     {
         if (1 === count($this->parents)) {
-          return $this->parents[0];
+            return $this->parents[0];
         }
         return $this->parents;
     }

--- a/src/RoleInterface.php
+++ b/src/RoleInterface.php
@@ -51,7 +51,7 @@ interface RoleInterface extends RecursiveIterator
     public function setParent($parent);
 
     /**
-     * @return null|RoleInterface
+     * @return null|RoleInterface|array
      */
     public function getParent();
 }

--- a/test/RbacTest.php
+++ b/test/RbacTest.php
@@ -209,4 +209,36 @@ class RbacTest extends TestCase
         $this->assertNull($editorRole->getParent());
         $this->assertNull($adminRole->getParent());
     }
+
+    public function testAddParentRole()
+    {
+        $adminRole = new Rbac\Role('Administrator');
+        $adminRole->addPermission('user.manage');
+        $this->rbac->addRole($adminRole);
+
+        $managerRole = new Rbac\Role('Manager');
+        $managerRole->addPermission('post.publish');
+        $managerRole->addParent($adminRole);
+        $this->rbac->addRole($managerRole);
+
+        $editorRole = new Rbac\Role('Editor');
+        $editorRole->addPermission('post.edit');
+        $this->rbac->addRole($editorRole);
+
+        $viewerRole = new Rbac\Role('Viewer');
+        $viewerRole->addPermission('post.view');
+        $viewerRole->addParent($editorRole);
+        $viewerRole->addParent($managerRole);
+        $this->rbac->addRole($viewerRole);
+
+        $this->assertEquals('Viewer', $editorRole->getChildren()->getName());
+        $this->assertEquals('Viewer', $managerRole->getChildren()->getName());
+        $this->assertTrue($this->rbac->isGranted('Editor', 'post.view'));
+        $this->assertTrue($this->rbac->isGranted('Manager', 'post.view'));
+
+        $this->assertEquals($viewerRole->getParent(), [ $editorRole, $managerRole ]);
+        $this->assertEquals($managerRole->getParent(), $adminRole);
+        $this->assertNull($editorRole->getParent());
+        $this->assertNull($adminRole->getParent());
+    }
 }

--- a/test/RbacTest.php
+++ b/test/RbacTest.php
@@ -180,4 +180,33 @@ class RbacTest extends TestCase
 
         $this->assertTrue($this->rbac->isGranted('parent', 'test'));
     }
+
+    public function testAddMultipleParentRole()
+    {
+        $adminRole = new Rbac\Role('Administrator');
+        $adminRole->addPermission('user.manage');
+        $this->rbac->addRole($adminRole);
+
+        $managerRole = new Rbac\Role('Manager');
+        $managerRole->addPermission('post.publish');
+        $this->rbac->addRole($managerRole, ['Administrator']);
+
+        $editorRole = new Rbac\Role('Editor');
+        $editorRole->addPermission('post.edit');
+        $this->rbac->addRole($editorRole);
+
+        $viewerRole = new Rbac\Role('Viewer');
+        $viewerRole->addPermission('post.view');
+        $this->rbac->addRole($viewerRole, ['Editor', 'Manager']);
+
+        $this->assertEquals('Viewer', $editorRole->getChildren()->getName());
+        $this->assertEquals('Viewer', $managerRole->getChildren()->getName());
+        $this->assertTrue($this->rbac->isGranted('Editor', 'post.view'));
+        $this->assertTrue($this->rbac->isGranted('Manager', 'post.view'));
+
+        $this->assertEquals($viewerRole->getParent(), [ $editorRole, $managerRole ]);
+        $this->assertEquals($managerRole->getParent(), $adminRole);
+        $this->assertNull($editorRole->getParent());
+        $this->assertNull($adminRole->getParent());
+    }
 }

--- a/test/RbacTest.php
+++ b/test/RbacTest.php
@@ -140,11 +140,9 @@ class RbacTest extends TestCase
         $this->rbac->addRole($bar, $foo);
 
         $this->assertEquals($bar->getParent(), $foo);
-        $this->assertTrue($foo->hasChildren());
-        $this->assertEquals($foo->getChildren(), $bar);
-        $this->assertFalse($bar->hasChildren());
-        $this->assertInstanceOf('Zend\Permissions\Rbac\Role', $foo->getChildren());
+        $this->assertEquals($bar, $foo->getChildren());
     }
+
 
     public function testAddRoleWithAutomaticParentsUsingRbac()
     {
@@ -155,10 +153,7 @@ class RbacTest extends TestCase
         $this->rbac->addRole($bar, $foo);
 
         $this->assertEquals($bar->getParent(), $foo);
-        $this->assertTrue($foo->hasChildren());
-        $this->assertEquals($foo->getChildren(), $bar);
-        $this->assertFalse($bar->hasChildren());
-        $this->assertInstanceOf('Zend\Permissions\Rbac\Role', $foo->getChildren());
+        $this->assertEquals($bar, $foo->getChildren());
     }
 
     /**
@@ -240,5 +235,32 @@ class RbacTest extends TestCase
         $this->assertEquals($managerRole->getParent(), $adminRole);
         $this->assertNull($editorRole->getParent());
         $this->assertNull($adminRole->getParent());
+    }
+
+    public function testAddTwoChildRole()
+    {
+        $foo = new Rbac\Role('foo');
+        $bar = new Rbac\Role('bar');
+        $baz = new Rbac\Role('baz');
+
+        $foo->addChild($bar);
+        $foo->addChild($baz);
+
+        $this->assertEquals($foo, $bar->getParent());
+        $this->assertEquals($bar, $foo->getChildren());
+        $foo->next();
+        $this->assertEquals($foo, $baz->getParent());
+        $this->assertEquals($baz, $foo->getChildren());
+    }
+
+    public function testAddSameParent()
+    {
+        $foo = new Rbac\Role('foo');
+        $bar = new Rbac\Role('bar');
+
+        $foo->addParent($bar);
+        $foo->addParent($bar);
+
+        $this->assertEquals($bar, $foo->getParent());
     }
 }


### PR DESCRIPTION
This PR fixes the #22 issue. It also provides a backward compatibility support in `Zend\Permissions\Rbac\AbstractRole::getParent()` for one parent case (the old behaviour reproduced in test).