### PR TITLE
spelling fixes

### DIFF
--- a/doc/book/methods.md
+++ b/doc/book/methods.md
@@ -27,7 +27,7 @@ Method signature                               | Description
 `getName() : string`                           | Retrieve the name assigned to this role.
 `hasPermission(string $name) : bool`           | Does the role have the given permission?
 `setParent(RoleInterface $parent) : void`      | Assign the provided role as the current role's parent.
-`getParent() null|RoleInterface`               | Retrive the current role's parent, if one exists.
+`getParent() null|RoleInterface`               | Retrieve the current role's parent, if one exists.
 
 ## `Zend\Permissions\Rbac\AssertionInterface`
 


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.