### PR TITLE
Fix test (and count usage with 7.2)

### DIFF
--- a/test/RbacTest.php
+++ b/test/RbacTest.php
@@ -136,7 +136,9 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $this->rbac->addRole($bar, $foo);
 
         $this->assertEquals($bar->getParent(), $foo);
+        $this->assertTrue($foo->hasChildren());
         $this->assertEquals($foo->getChildren(), $bar);
+        $this->assertFalse($bar->hasChildren());
         $this->assertInstanceOf('Zend\Permissions\Rbac\Role', $foo->getChildren());
     }
 
@@ -149,7 +151,9 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $this->rbac->addRole($bar, $foo);
 
         $this->assertEquals($bar->getParent(), $foo);
+        $this->assertTrue($foo->hasChildren());
         $this->assertEquals($foo->getChildren(), $bar);
+        $this->assertFalse($bar->hasChildren());
         $this->assertInstanceOf('Zend\Permissions\Rbac\Role', $foo->getChildren());
     }
 

--- a/test/RbacTest.php
+++ b/test/RbacTest.php
@@ -136,7 +136,8 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $this->rbac->addRole($bar, $foo);
 
         $this->assertEquals($bar->getParent(), $foo);
-        $this->assertEquals(1, count($foo->getChildren()));
+        $this->assertEquals($foo->getChildren(), $bar);
+        $this->assertInstanceOf('Zend\Permissions\Rbac\Role', $foo->getChildren());
     }
 
     public function testAddRoleWithAutomaticParentsUsingRbac()
@@ -148,7 +149,8 @@ class RbacTest extends \PHPUnit_Framework_TestCase
         $this->rbac->addRole($bar, $foo);
 
         $this->assertEquals($bar->getParent(), $foo);
-        $this->assertEquals(1, count($foo->getChildren()));
+        $this->assertEquals($foo->getChildren(), $bar);
+        $this->assertInstanceOf('Zend\Permissions\Rbac\Role', $foo->getChildren());
     }
 
     /**


### PR DESCRIPTION
Discovered in Fedora QA with PHP 7.2.0RC5
https://apps.fedoraproject.org/koschei/package/php-zendframework-zend-permissions-rbac?collection=f28

```
There were 2 errors:
1) ZendTest\Permissions\Rbac\RbacTest::testAddRoleWithParentsUsingRbac
count(): Parameter must be an array or an object that implements Countable
/builddir/build/BUILD/zend-permissions-rbac-4213a4889ae7d7607c7974124965d12d1c395115/test/RbacTest.php:139
2) ZendTest\Permissions\Rbac\RbacTest::testAddRoleWithAutomaticParentsUsingRbac
count(): Parameter must be an array or an object that implements Countable
/builddir/build/BUILD/zend-permissions-rbac-4213a4889ae7d7607c7974124965d12d1c395115/test/RbacTest.php:151
```

IMHO, the count is this test doesn't make sense, as `$foo->getChildren()` return `$bar` which have no child., BTW if "count" is really wanted, `AbstractRole` should implement `Countable`.