### PR TITLE
Added Role::getPermissions(), Rbac::getRoles()

### DIFF
--- a/doc/book/methods.md
+++ b/doc/book/methods.md
@@ -4,16 +4,17 @@
 
 The `Role` provides the base functionality required by the `RoleInterface`.
 
-Method signature                          | Description
-------------------------------------------| -----------
-`__construct(string $name) : void`        | Create a new instance with the provided name.
-`getName() : string`                      | Retrieve the name assigned to this role.
-`addPermission(string $name) : void`      | Add a permission for the current role.
-`hasPermission(string $name) : bool`      | Does the role have the given permission?
-`addChild(RoleInterface $child) : Role`   | Add a child role to the current instance.
-`getChildren() : RoleInterface[]`         | Get all the children roles.
-`addParent(RoleInterface $parent) : Role` | Add a parent role to the current instance.
-`getParents() : RoleInterface[]`          | Get all the parent roles.
+Method signature                                | Description
+------------------------------------------------| -----------
+`__construct(string $name) : void`              | Create a new instance with the provided name.
+`getName() : string`                            | Retrieve the name assigned to this role.
+`addPermission(string $name) : void`            | Add a permission for the current role.
+`hasPermission(string $name) : bool`            | Does the role have the given permission?
+`getPermissions(bool $children = true) : array` | Retrieve all the permissions, including children if `$children` is true
+`addChild(RoleInterface $child) : Role`         | Add a child role to the current instance.
+`getChildren() : RoleInterface[]`               | Get all the children roles.
+`addParent(RoleInterface $parent) : Role`       | Add a parent role to the current instance.
+`getParents() : RoleInterface[]`                | Get all the parent roles.
 
 ## `Zend\Permissions\Rbac\AssertionInterface`
 
@@ -29,11 +30,12 @@ Method signature                                                     | Descripti
 `Rbac` is the object with which you will interact within your application in
 order to query for permissions.
 
-Method signature                                                            | Description
---------------------------------------------------------------------------- | -----------
+Method signature                                                              | Description
+----------------------------------------------------------------------------- | -----------
 `addRole(string\|RoleInterface $child, array\|RoleInterface $parents = null)` | Add a role to the RBAC. If `$parents` is non-null, the `$child` is also added to any parents provided.
-`getRole(string $role) : RoleInterface`                                     | Get the role specified by name, raising an exception if not found.
-`hasRole(string\|RoleInterface $role) : bool`                                | Recursively queries the RBAC for the given role, returning `true` if found, `false` otherwise.
-`getCreateMissingRoles() : bool`                                            | Retrieve the flag that determines whether or not `$parent` roles are added automatically if not present when calling `addRole()`.
-`setCreateMissingRoles(bool $flag) : void`                                  | Set the flag that determines whether or not `$parent` roles are added automatically if not present when calling `addRole()`.
-`isGranted(string\|RoleInterface $role, string $permission, $assert = null)` | Determine if the role has the given permission. If `$assert` is provided and either an `AssertInterface` instance or callable, it will be queried before checking against the given role.
+`getRole(string $role) : RoleInterface`                                       | Get the role specified by name, raising an exception if not found.
+`getRoles(): RoleInterface[]`                                                 | Retrieve all the roles
+`hasRole(string\|RoleInterface $role) : bool`                                 | Recursively queries the RBAC for the given role, returning `true` if found, `false` otherwise.
+`getCreateMissingRoles() : bool`                                              | Retrieve the flag that determines whether or not `$parent` roles are added automatically if not present when calling `addRole()`.
+`setCreateMissingRoles(bool $flag) : void`                                    | Set the flag that determines whether or not `$parent` roles are added automatically if not present when calling `addRole()`.
+`isGranted(string\|RoleInterface $role, string $permission, $assert = null)`  | Determine if the role has the given permission. If `$assert` is provided and either an `AssertInterface` instance or callable, it will be queried before checking against the given role.

--- a/src/Rbac.php
+++ b/src/Rbac.php
@@ -108,7 +108,7 @@ class Rbac
     }
 
     /**
-     * Return all the roles, included the children roles if $children == true
+     * Return all the roles
      *
      * @return RoleInterface[]
      */

--- a/src/Rbac.php
+++ b/src/Rbac.php
@@ -108,6 +108,16 @@ class Rbac
     }
 
     /**
+     * Return all the roles, included the children roles if $children == true
+     *
+     * @return RoleInterface[]
+     */
+    public function getRoles(): array
+    {
+        return array_values($this->roles);
+    }
+
+    /**
      * Determines if access is granted by checking the role and child roles for permission.
      *
      * @param RoleInterface|string $role

--- a/src/Role.php
+++ b/src/Role.php
@@ -71,6 +71,21 @@ class Role implements RoleInterface
     }
 
     /**
+     * Get the permissions of the role, included all the permissions
+     * of the children if $children == true
+     */
+    public function getPermissions(bool $children = true) : array
+    {
+        $permissions = (array) key($this->permissions);
+        if ($children) {
+            foreach ($this->children as $child) {
+                $permissions = array_merge($permissions, $child->getPermissions());
+            }
+        }
+        return $permissions;
+    }
+
+    /**
      * Add a child rold.
      *
      * @throws Exception\CircularReferenceException

--- a/test/RbacTest.php
+++ b/test/RbacTest.php
@@ -119,7 +119,7 @@ class RbacTest extends TestCase
         $this->assertFalse($this->rbac->hasRole('baz'));
 
         // check that 'snafu' role and $snafu are different
-        $this->assertNotEquals($this->rbac->getRole('snafu'), $snafu);
+        $this->assertNotEquals($snafu, $this->rbac->getRole('snafu'));
         $this->assertTrue($this->rbac->hasRole('snafu'));
         $this->assertFalse($this->rbac->hasRole($snafu));
     }
@@ -171,7 +171,7 @@ class RbacTest extends TestCase
         $this->rbac->addRole($foo);
         $this->rbac->addRole($bar, $foo);
 
-        $this->assertEquals($bar->getParents(), [$foo]);
+        $this->assertEquals([$foo], $bar->getParents());
         $this->assertEquals([$bar], $foo->getChildren());
     }
 
@@ -185,7 +185,7 @@ class RbacTest extends TestCase
         $this->assertTrue($this->rbac->getCreateMissingRoles());
         $this->rbac->addRole($bar, $foo);
 
-        $this->assertEquals($bar->getParents(), [$foo]);
+        $this->assertEquals([$foo], $bar->getParents());
         $this->assertEquals([$bar], $foo->getChildren());
     }
 
@@ -233,8 +233,8 @@ class RbacTest extends TestCase
         $this->assertTrue($this->rbac->isGranted('Editor', 'post.view'));
         $this->assertTrue($this->rbac->isGranted('Manager', 'post.view'));
 
-        $this->assertEquals($viewerRole->getParents(), [$editorRole, $managerRole]);
-        $this->assertEquals($managerRole->getParents(), [$adminRole]);
+        $this->assertEquals([$editorRole, $managerRole], $viewerRole->getParents());
+        $this->assertEquals([$adminRole], $managerRole->getParents());
         $this->assertEmpty($editorRole->getParents());
         $this->assertEmpty($adminRole->getParents());
     }
@@ -263,8 +263,8 @@ class RbacTest extends TestCase
         // Check roles hierarchy
         $this->assertEquals([$viewerRole], $editorRole->getChildren());
         $this->assertEquals([$viewerRole], $managerRole->getChildren());
-        $this->assertEquals($viewerRole->getParents(), [$editorRole, $managerRole]);
-        $this->assertEquals($managerRole->getParents(), [$adminRole]);
+        $this->assertEquals([$editorRole, $managerRole], $viewerRole->getParents());
+        $this->assertEquals([$adminRole], $managerRole->getParents());
         $this->assertEmpty($editorRole->getParents());
         $this->assertEmpty($adminRole->getParents());
 
@@ -296,11 +296,11 @@ class RbacTest extends TestCase
         $managerRole->addParent($adminRole);
         $this->rbac->addRole($managerRole);
 
-        $this->assertEquals($this->rbac->getRoles(), [$adminRole, $managerRole]);
+        $this->assertEquals([$adminRole, $managerRole], $this->rbac->getRoles());
     }
 
     public function testEmptyRoles()
     {
-        $this->assertEquals($this->rbac->getRoles(), []);
+        $this->assertEquals([], $this->rbac->getRoles());
     }
 }

--- a/test/RbacTest.php
+++ b/test/RbacTest.php
@@ -285,27 +285,22 @@ class RbacTest extends TestCase
         $this->assertFalse($this->rbac->isGranted('Manager', 'user.manage'));
     }
 
-    public function testAddTwoChildRole()
+    public function testGetRoles()
     {
-        $foo = new Rbac\Role('foo');
-        $bar = new Rbac\Role('bar');
-        $baz = new Rbac\Role('baz');
+        $adminRole = new Rbac\Role('Administrator');
+        $adminRole->addPermission('user.manage');
+        $this->rbac->addRole($adminRole);
 
-        $foo->addChild($bar);
-        $foo->addChild($baz);
+        $managerRole = new Rbac\Role('Manager');
+        $managerRole->addPermission('post.publish');
+        $managerRole->addParent($adminRole);
+        $this->rbac->addRole($managerRole);
 
-        $this->assertEquals([$foo], $bar->getParents());
-        $this->assertEquals([$bar, $baz], $foo->getChildren());
+        $this->assertEquals($this->rbac->getRoles(), [$adminRole, $managerRole]);
     }
 
-    public function testAddSameParent()
+    public function testEmptyRoles()
     {
-        $foo = new Rbac\Role('foo');
-        $bar = new Rbac\Role('bar');
-
-        $foo->addParent($bar);
-        $foo->addParent($bar);
-
-        $this->assertEquals([$bar], $foo->getParents());
+        $this->assertEquals($this->rbac->getRoles(), []);
     }
 }

--- a/test/RoleTest.php
+++ b/test/RoleTest.php
@@ -55,7 +55,7 @@ class RoleTest extends TestCase
         $foo->addChild($bar);
         $foo->addChild($baz);
 
-        $this->assertEquals($foo->getChildren(), [$bar, $baz]);
+        $this->assertEquals([$bar, $baz], $foo->getChildren());
     }
 
     public function testAddParent()
@@ -66,7 +66,7 @@ class RoleTest extends TestCase
 
         $foo->addParent($bar);
         $foo->addParent($baz);
-        $this->assertEquals($foo->getParents(), [$bar, $baz]);
+        $this->assertEquals([$bar, $baz], $foo->getParents());
     }
 
     public function testPermissionHierarchy()
@@ -138,27 +138,27 @@ class RoleTest extends TestCase
         $foo->addParent($bar);
         $foo->addChild($baz);
 
-        $this->assertEquals($bar->getPermissions(), [
+        $this->assertEquals([
             'bar.permission',
             'foo.permission',
             'baz.permission'
-        ]);
-        $this->assertEquals($bar->getPermissions(false), [
+        ], $bar->getPermissions());
+        $this->assertEquals([
             'bar.permission'
-        ]);
-        $this->assertEquals($foo->getPermissions(), [
+        ], $bar->getPermissions(false));
+        $this->assertEquals([
             'foo.permission',
             'baz.permission'
-        ]);
-        $this->assertEquals($foo->getPermissions(false), [
+        ], $foo->getPermissions());
+        $this->assertEquals([
             'foo.permission'
-        ]);
-        $this->assertEquals($baz->getPermissions(), [
+        ], $foo->getPermissions(false));
+        $this->assertEquals([
             'baz.permission'
-        ]);
-        $this->assertEquals($baz->getPermissions(false), [
+        ], $baz->getPermissions());
+        $this->assertEquals([
             'baz.permission'
-        ]);
+        ], $baz->getPermissions(false));
     }
 
     public function testAddTwoChildRole()

--- a/test/RoleTest.php
+++ b/test/RoleTest.php
@@ -122,4 +122,66 @@ class RoleTest extends TestCase
         $this->expectException(Exception\CircularReferenceException::class);
         $baz->addParent($foo);
     }
+
+    public function testGetPermissions()
+    {
+        $foo = new Role('foo');
+        $foo->addPermission('foo.permission');
+
+        $bar = new Role('bar');
+        $bar->addPermission('bar.permission');
+
+        $baz = new Role('baz');
+        $baz->addPermission('baz.permission');
+
+        // create hierarchy bar -> foo -> baz
+        $foo->addParent($bar);
+        $foo->addChild($baz);
+
+        $this->assertEquals($bar->getPermissions(), [
+            'bar.permission',
+            'foo.permission',
+            'baz.permission'
+        ]);
+        $this->assertEquals($bar->getPermissions(false), [
+            'bar.permission'
+        ]);
+        $this->assertEquals($foo->getPermissions(), [
+            'foo.permission',
+            'baz.permission'
+        ]);
+        $this->assertEquals($foo->getPermissions(false), [
+            'foo.permission'
+        ]);
+        $this->assertEquals($baz->getPermissions(), [
+            'baz.permission'
+        ]);
+        $this->assertEquals($baz->getPermissions(false), [
+            'baz.permission'
+        ]);
+    }
+
+    public function testAddTwoChildRole()
+    {
+        $foo = new Role('foo');
+        $bar = new Role('bar');
+        $baz = new Role('baz');
+
+        $foo->addChild($bar);
+        $foo->addChild($baz);
+
+        $this->assertEquals([$foo], $bar->getParents());
+        $this->assertEquals([$bar, $baz], $foo->getChildren());
+    }
+
+    public function testAddSameParent()
+    {
+        $foo = new Role('foo');
+        $bar = new Role('bar');
+
+        $foo->addParent($bar);
+        $foo->addParent($bar);
+
+        $this->assertEquals([$bar], $foo->getParents());
+    }
 }

--- a/test/RoleTest.php
+++ b/test/RoleTest.php
@@ -143,19 +143,24 @@ class RoleTest extends TestCase
             'foo.permission',
             'baz.permission'
         ], $bar->getPermissions());
+
         $this->assertEquals([
             'bar.permission'
         ], $bar->getPermissions(false));
+
         $this->assertEquals([
             'foo.permission',
             'baz.permission'
         ], $foo->getPermissions());
+
         $this->assertEquals([
             'foo.permission'
         ], $foo->getPermissions(false));
+
         $this->assertEquals([
             'baz.permission'
         ], $baz->getPermissions());
+
         $this->assertEquals([
             'baz.permission'
         ], $baz->getPermissions(false));


### PR DESCRIPTION
This PR adds 2 functions:
- `Role::getPermissions($children = true)`, retrieve all the permissions of a role, included the children permission if `$children` is true;
- `Rbac::getRoles()`, returns all the roles as array of `RoleInterface`;

These functions are useful for getting the permissions and roles of a Rbac scheme.
