### PR TITLE
Use iterable type hints

### DIFF
--- a/src/RoleInterface.php
+++ b/src/RoleInterface.php
@@ -36,7 +36,7 @@ interface RoleInterface
      *
      * @return RoleInterface[]
      */
-    public function getChildren() : array;
+    public function getChildren() : iterable;
 
     /**
      * Add a parent.
@@ -48,5 +48,5 @@ interface RoleInterface
      *
      * @return RoleInterface[]
      */
-    public function getParents() : array;
+    public function getParents() : iterable;
 }


### PR DESCRIPTION
To allow the RoleInterface getChildren() and getParents() methods to return a traversable object as well as an array.

Anyone else interested in this? If so I can look at adding a test, not sure if its required though?